### PR TITLE
Update map with climate annual features

### DIFF
--- a/arboverse/static/js/mapboxutil.js
+++ b/arboverse/static/js/mapboxutil.js
@@ -132,9 +132,125 @@ function update_map(cb) {
     console.log(cb.checked);
 }
 
+clickedLayer_old = ""
 
+function update_map_time(cb, model, year, prefix) {
+    var yearFinal = parseInt(year)+30
+    var clickedLayer = "arboverse."+prefix+"_"+model+"_"+year+"_"+yearFinal
+    console.log(clickedLayer);
+    if (cb.checked) {
+        if(clickedLayer_old != ""){
+            map.setLayoutProperty(
+                clickedLayer_old,
+                'visibility',
+                'none'
+            ); 
+        }
+        clickedLayer_old = clickedLayer
+        map.setLayoutProperty(
+            clickedLayer,
+            'visibility',
+            'visible'
+        );
+    } else {
+        map.setLayoutProperty(
+            clickedLayer_old,
+            'visibility',
+            'none'
+        ); 
+    }
+    console.log(cb.checked);
+}
 
 map.on('load', async()=>{
+    //Annual temperature
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_1985_2015', 'mapbox://arboverse.temp_min_rcp45_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_1985_2015', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_1985_2015', 'mapbox://arboverse.temp_average_rcp45_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_1985_2015', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_1985_2015', 'mapbox://arboverse.temp_max_rcp45_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_1985_2015', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_1985_2015', 'mapbox://arboverse.temp_min_rcp85_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_1985_2015', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_1985_2015', 'mapbox://arboverse.temp_average_rcp85_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_1985_2015', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_1985_2015', 'mapbox://arboverse.temp_max_rcp85_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_1985_2015', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_1995_2025', 'mapbox://arboverse.temp_min_rcp45_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_1995_2025', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_1995_2025', 'mapbox://arboverse.temp_average_rcp45_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_1995_2025', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_1995_2025', 'mapbox://arboverse.temp_max_rcp45_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_1995_2025', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_1995_2025', 'mapbox://arboverse.temp_min_rcp85_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_1995_2025', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_1995_2025', 'mapbox://arboverse.temp_average_rcp85_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_1995_2025', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_1995_2025', 'mapbox://arboverse.temp_max_rcp85_1995_2025', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_1995_2025', 0, 19);
+    
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2005_2035', 'mapbox://arboverse.temp_min_rcp45_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2005_2035', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2005_2035', 'mapbox://arboverse.temp_average_rcp45_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2005_2035', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2005_2035', 'mapbox://arboverse.temp_max_rcp45_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2005_2035', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2005_2035', 'mapbox://arboverse.temp_min_rcp85_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2005_2035', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2005_2035', 'mapbox://arboverse.temp_average_rcp85_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2005_2035', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2005_2035', 'mapbox://arboverse.temp_max_rcp85_2005_2035', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2005_2035', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2015_2045', 'mapbox://arboverse.temp_min_rcp45_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2015_2045', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2015_2045', 'mapbox://arboverse.temp_average_rcp45_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2015_2045', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2015_2045', 'mapbox://arboverse.temp_max_rcp45_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2015_2045', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2015_2045', 'mapbox://arboverse.temp_min_rcp85_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2015_2045', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2015_2045', 'mapbox://arboverse.temp_average_rcp85_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2015_2045', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2015_2045', 'mapbox://arboverse.temp_max_rcp85_2015_2045', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2015_2045', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2025_2055', 'mapbox://arboverse.temp_min_rcp45_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2025_2055', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2025_2055', 'mapbox://arboverse.temp_average_rcp45_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2025_2055', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2025_2055', 'mapbox://arboverse.temp_max_rcp45_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2025_2055', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2025_2055', 'mapbox://arboverse.temp_min_rcp85_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2025_2055', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2025_2055', 'mapbox://arboverse.temp_average_rcp85_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2025_2055', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2025_2055', 'mapbox://arboverse.temp_max_rcp85_2025_2055', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2025_2055', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2035_2065', 'mapbox://arboverse.temp_min_rcp45_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2035_2065', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2035_2065', 'mapbox://arboverse.temp_average_rcp45_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2035_2065', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2035_2065', 'mapbox://arboverse.temp_max_rcp45_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2035_2065', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2035_2065', 'mapbox://arboverse.temp_min_rcp85_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2035_2065', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2035_2065', 'mapbox://arboverse.temp_average_rcp85_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2035_2065', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2035_2065', 'mapbox://arboverse.temp_max_rcp85_2035_2065', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2035_2065', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2045_2075', 'mapbox://arboverse.temp_min_rcp45_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2045_2075', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2045_2075', 'mapbox://arboverse.temp_average_rcp45_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2045_2075', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2045_2075', 'mapbox://arboverse.temp_max_rcp45_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2045_2075', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2045_2075', 'mapbox://arboverse.temp_min_rcp85_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2045_2075', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2045_2075', 'mapbox://arboverse.temp_average_rcp85_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2045_2075', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2045_2075', 'mapbox://arboverse.temp_max_rcp85_2045_2075', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2045_2075', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2055_2085', 'mapbox://arboverse.temp_min_rcp45_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2055_2085', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2055_2085', 'mapbox://arboverse.temp_average_rcp45_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2055_2085', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2055_2085', 'mapbox://arboverse.temp_max_rcp45_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2055_2085', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2055_2085', 'mapbox://arboverse.temp_min_rcp85_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2055_2085', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2055_2085', 'mapbox://arboverse.temp_average_rcp85_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2055_2085', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2055_2085', 'mapbox://arboverse.temp_max_rcp85_2055_2085', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2055_2085', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2065_2095', 'mapbox://arboverse.temp_min_rcp45_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2065_2095', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2065_2095', 'mapbox://arboverse.temp_average_rcp45_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2065_2095', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2065_2095', 'mapbox://arboverse.temp_max_rcp45_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2065_2095', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2065_2095', 'mapbox://arboverse.temp_min_rcp85_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2065_2095', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2065_2095', 'mapbox://arboverse.temp_average_rcp85_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2065_2095', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2065_2095', 'mapbox://arboverse.temp_max_rcp85_2065_2095', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2065_2095', 0, 19);
+
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2075_2105', 'mapbox://arboverse.temp_min_rcp45_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2075_2105', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2075_2105', 'mapbox://arboverse.temp_average_rcp45_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2075_2105', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2075_2105', 'mapbox://arboverse.temp_max_rcp45_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2075_2105', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2075_2105', 'mapbox://arboverse.temp_min_rcp85_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2075_2105', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2075_2105', 'mapbox://arboverse.temp_average_rcp85_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2075_2105', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2075_2105', 'mapbox://arboverse.temp_max_rcp85_2075_2105', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2075_2105', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2085_2115', 'mapbox://arboverse.temp_min_rcp45_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2085_2115', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2085_2115', 'mapbox://arboverse.temp_average_rcp45_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2085_2115', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2085_2115', 'mapbox://arboverse.temp_max_rcp45_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2085_2115', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2085_2115', 'mapbox://arboverse.temp_min_rcp85_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2085_2115', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2085_2115', 'mapbox://arboverse.temp_average_rcp85_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2085_2115', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2085_2115', 'mapbox://arboverse.temp_max_rcp85_2085_2115', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2085_2115', 0, 19);
+
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp45_2095_2125', 'mapbox://arboverse.temp_min_rcp45_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_2095_2125', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp45_2095_2125', 'mapbox://arboverse.temp_average_rcp45_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp45_2095_2125', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp45_2095_2125', 'mapbox://arboverse.temp_max_rcp45_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp45_2095_2125', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_min_rcp85_2095_2125', 'mapbox://arboverse.temp_min_rcp85_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp85_2095_2125', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_average_rcp85_2095_2125', 'mapbox://arboverse.temp_average_rcp85_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_average_rcp85_2095_2125', 0, 19);
+    addRasterTileLayerToMap(map, 'arboverse.temp_max_rcp85_2095_2125', 'mapbox://arboverse.temp_max_rcp85_2095_2125', 'raster', 'mapbox://arboverse.arboverse.temp_max_rcp85_2095_2125', 0, 19);
+
+    //Hot days
+    addRasterTileLayerToMap(map, 'arboverse.hot_days_yr_rcp45_1985_2015', 'mapbox://arboverse.temp_min_rcp45_1985_2015', 'raster', 'mapbox://arboverse.arboverse.temp_min_rcp45_1985_2015', 0, 19);
     //Koppengeiger 
     addTileLayerToMap(map, 'arboverse.presentfull', 'mapbox://arboverse.presentfull', 'fill', { 'fill-color': [ "case", [ "==", ["get", "classes"], 0 ], "hsla(0, 0%, 0%, 0)", [ "match", ["get", "classes"], [1], true, false ], "#8c0273", [ "match", ["get", "classes"], [2], true, false ], "#8f1966", [ "match", ["get", "classes"], [3], true, false ], "#91285a", [ "match", ["get", "classes"], [4], true, false ], "#922e54", [ "match", ["get", "classes"], [5], true, false ], "#943c4a", [ "match", ["get", "classes"], [6], true, false ], "#964941", [ "match", ["get", "classes"], [7], true, false ], "#974f3c", [ "match", ["get", "classes"], [8], true, false ], "#996330", [ "match", ["get", "classes"], [9], true, false ], "#9a692b", [ "match", ["get", "classes"], [10], true, false ], "#9b7127", [ "match", ["get", "classes"], [11], true, false ], "#9c7923", [ "match", ["get", "classes"], [12], true, false ], "#9c801f", [ "match", ["get", "classes"], [13], true, false ], "#9d891c", [ "match", ["get", "classes"], [14], true, false ], "#9c911c", [ "match", ["get", "classes"], [15], true, false ], "#9b9a1d", [ "match", ["get", "classes"], [16], true, false ], "#99a323", [ "match", ["get", "classes"], [17], true, false ], "#91b437", [ "match", ["get", "classes"], [18], true, false ], "#8cba44", [ "match", ["get", "classes"], [19], true, false ], "#86c051", [ "match", ["get", "classes"], [20], true, false ], "#80c55f", [ "match", ["get", "classes"], [21], true, false ], "#79ca6d", [ "match", ["get", "classes"], [22], true, false ], "#73ce7b", [ "match", ["get", "classes"], [23], true, false ], "#6dd389", [ "match", ["get", "classes"], [24], true, false ], "#68d797", [ "match", ["get", "classes"], [26], true, false ], "#60e0b5", [ "match", ["get", "classes"], [27], true, false ], "#60e4c4", [ "match", ["get", "classes"], [28], true, false ], "#65e8d2", [ "match", ["get", "classes"], [29], true, false ], "#8ff0f1", [ "match", ["get", "classes"], [30], true, false ], "#b3f2fd", [ "match", ["get", "classes"], [25], true, false ], "#62dca7", "#000000" ]}, 'kopeen_fullpresent');
     addTileLayerToMap(map, 'arboverse.koppenfuture', 'mapbox://arboverse.koppenfuture', 'fill', { 'fill-color': [ "case", [ "==", ["get", "classes"], 0 ], "hsla(0, 0%, 0%, 0)", [ "match", ["get", "classes"], [1], true, false ], "#8c0273", [ "match", ["get", "classes"], [2], true, false ], "#8f1966", [ "match", ["get", "classes"], [3], true, false ], "#91285a", [ "match", ["get", "classes"], [4], true, false ], "#922e54", [ "match", ["get", "classes"], [5], true, false ], "#943c4a", [ "match", ["get", "classes"], [6], true, false ], "#964941", [ "match", ["get", "classes"], [7], true, false ], "#974f3c", [ "match", ["get", "classes"], [8], true, false ], "#996330", [ "match", ["get", "classes"], [9], true, false ], "#9a692b", [ "match", ["get", "classes"], [10], true, false ], "#9b7127", [ "match", ["get", "classes"], [11], true, false ], "#9c7923", [ "match", ["get", "classes"], [12], true, false ], "#9c801f", [ "match", ["get", "classes"], [13], true, false ], "#9d891c", [ "match", ["get", "classes"], [14], true, false ], "#9c911c", [ "match", ["get", "classes"], [15], true, false ], "#9b9a1d", [ "match", ["get", "classes"], [16], true, false ], "#99a323", [ "match", ["get", "classes"], [17], true, false ], "#91b437", [ "match", ["get", "classes"], [18], true, false ], "#8cba44", [ "match", ["get", "classes"], [19], true, false ], "#86c051", [ "match", ["get", "classes"], [20], true, false ], "#80c55f", [ "match", ["get", "classes"], [21], true, false ], "#79ca6d", [ "match", ["get", "classes"], [22], true, false ], "#73ce7b", [ "match", ["get", "classes"], [23], true, false ], "#6dd389", [ "match", ["get", "classes"], [24], true, false ], "#68d797", [ "match", ["get", "classes"], [26], true, false ], "#60e0b5", [ "match", ["get", "classes"], [27], true, false ], "#60e4c4", [ "match", ["get", "classes"], [28], true, false ], "#65e8d2", [ "match", ["get", "classes"], [29], true, false ], "#8ff0f1", [ "match", ["get", "classes"], [30], true, false ], "#b3f2fd", [ "match", ["get", "classes"], [25], true, false ], "#62dca7", "#000000" ]}, 'kopeen_future');

--- a/arboverse/static/js/menu.js
+++ b/arboverse/static/js/menu.js
@@ -224,13 +224,84 @@ var i = 0;
 function showChekedCli() {
     document.getElementById('check4').textContent = document.querySelectorAll("input[name=climate]:checked").length;
 }
+function annual_switch() {
+    if(!document.querySelector("input[name=model_selector][id=model_1]").checked && !document.querySelector("input[name=model_selector][id=model_2]").checked){
+        document.querySelector("input[name=model_selector][id=model_1]").checked = true;
+    }
+    if(!document.querySelector("input[name=annual_time][id=temp_min]").checked && !document.querySelector("input[name=annual_time][id=temp_average]").checked && !document.querySelector("input[name=annual_time][id=temp_max]").checked){
+        document.querySelector("input[name=annual_time][id=temp_average]").checked = true;
+    }
+
+    temp = document.querySelector('input[name=annual_time]:checked').value;
+    model = document.querySelector('input[name=model_selector]:checked').value;
+    year = document.querySelector('input[name=annual]').value;
+    
+    return [model, year, temp];
+}
+
+document.querySelectorAll("input[name=annual_time]").forEach(i => {
+    i.onchange = function(){
+        cb = document.querySelector("input[name=climate][id=annual_switch]")
+        if(cb.checked){
+            var [model, year, temp] = annual_switch();
+            update_map_time(cb, model, year, temp);
+        }
+    } 
+});
+
+document.querySelectorAll("input[name=model_selector]").forEach(i => {
+    i.onchange = function(){
+        cb = document.querySelector("input[name=climate][id=annual_switch]")
+        if(cb.checked){
+            var [model, year, temp] = annual_switch();
+            update_map_time(cb, model, year, temp);
+        }
+    } 
+});
+
+document.querySelectorAll("input[name=annual]").forEach(i => {
+    i.onchange = function(){
+        cb = document.querySelector("input[name=climate][id=annual_switch]")
+        if(cb.checked){
+            var [model, year, temp] = annual_switch();
+            update_map_time(cb, model, year, temp);
+        }
+    } 
+});
+
 document.querySelectorAll("input[name=climate]").forEach(i => {
-    i.onclick = function () {
-        showChekedCli();
-        update_map(this);
-        update_map_time(this);
+    console.log(i.id)
+    if(i.id == "annual_switch"){
+        i.onclick = function () {
+            showChekedCli();
+            var [model, year, temp] = annual_switch();
+            update_map_time(this, model, year, temp);
+        }
+    }else if(i.id == "hotdays_switch"){
+        i.onclick = function () {
+            if(!document.querySelector("input[name=hotdays_model][id=model_1]").checked && !document.querySelector("input[name=hotdays_model][id=model_2]").checked){
+                document.querySelector("input[name=hotdays_model][id=model_1]").checked = true;
+            }
+            showChekedCli();
+            prefix = "hot_days_yr";
+            model = document.querySelector('input[name=hotdays_model]:checked').value;
+            year = document.querySelector('input[name=hotdays_year]').value;
+            update_map_time(this, model, year, prefix);
+        }
+    }else{
+        i.onclick = function () {
+            showChekedCli();
+            update_map(this);
+        }
     }
 });
+
+document.querySelectorAll("input[name=annual]").forEach(i => {
+    i.onclick = function () {
+        console.log(this.value)
+    }
+});
+
 //Checked Forest
 showChekedFor();
 var i = 0;

--- a/arboverse/templates/pages/arboverse.html
+++ b/arboverse/templates/pages/arboverse.html
@@ -1090,20 +1090,20 @@
               <h5 id="form-title">Select layer type and model</h5>
               <div id="time-annual-slider">
                 <form name="annual_time">
-                  <input type="radio" name="annual_time" value="temp_min">
+                  <input type="radio" name="annual_time" id="temp_min" value="temp_min">
                   <label for="temp_min" data-time-amount="Minimal" ></label>
-                  <input type="radio" name="annual_time" value="temp_average">
+                  <input type="radio" name="annual_time" id="temp_average" value="temp_average">
                   <label for="temp_average" data-time-amount="Average"></label>
-                  <input type="radio" name="annual_time" value="temp_max">
+                  <input type="radio" name="annual_time" id="temp_max" value="temp_max">
                   <label for="temp_max" data-time-amount="Maximal"></label>
                 </form>
               </div>
             </form>
             <form>
               <div class="model_group">
-                <input type="radio" id="model_1" name="model_selector">
+                <input type="radio" id="model_1" name="model_selector" value="rcp45">
                 <label for="model_1">RCP 45</label>
-                <input type="radio" id="model_2" name="model_selector">
+                <input type="radio" id="model_2" name="model_selector" value="rcp85">
                 <label for="model_2">RCP 85</label>
               </div>
             </form>
@@ -1120,7 +1120,7 @@
           <div class="unit-toggle">
             <div class="togglebtn">
               <label class="switch">
-                <input type="checkbox" name="climate" id=" " />
+                <input type="checkbox" name="climate" id="hotdays_switch" />
                 <span class="slider round"></span>
               </label>
             </div>
@@ -1152,9 +1152,9 @@
             <h5 class="select-title">Select layer model</h5>
             <form>
               <div class="model_group">
-                <input type="radio" value="rcp45" name="hotdays_model">
+                <input type="radio" id="model_1" name="hotdays_model" value="rcp45">
                 <label for="rcp45">RCP 45</label>
-                <input type="radio" value="rcp85" name="hotdays_model">
+                <input type="radio" id="model_2" name="hotdays_model" value="rcp85">
                 <label for="rcp85">RCP 85</label>
               </div>
             </form>


### PR DESCRIPTION
I create the events handler in `menu.js` to get the click in annual temperature. When this check box in clicked I get the values of model [min, average, max] and [rcp45, rcp85] and time series [1985...2095] with the function `annual_switch`. After I call the function `update_map_time` that is located in `mapboxutil.js`. In the last I combine the values of model and time to enable or disable the layer correspondent layer visibility.
I did the same approach in the event handler on change for the components `annual_time`, `model_selector`, `annual`.

At first all the event handler need to be replicated for each feature, like hot days and so on, but the function `update_map_time` doesn't need to be replicated.

Please, let me now if the function has de desired behavior .